### PR TITLE
Ensures ProfileTrustAgent properly grants/revokes trust [2/2]

### DIFF
--- a/sdk/src/java/cyanogenmod/app/ProfileManager.java
+++ b/sdk/src/java/cyanogenmod/app/ProfileManager.java
@@ -84,6 +84,29 @@ public class ProfileManager {
     public static final String INTENT_ACTION_PROFILE_UPDATED =
             "cyanogenmod.platform.intent.action.PROFILE_UPDATED";
 
+
+    /**
+     * @hide
+     */
+    public static final String INTENT_ACTION_PROFILE_TRIGGER_STATE_CHANGED =
+            "cyanogenmod.platform.intent.action.INTENT_ACTION_PROFILE_TRIGGER_STATE_CHANGED";
+
+    /**
+     * @hide
+     */
+    public static final String EXTRA_TRIGGER_ID = "trigger_id";
+
+    /**
+     * @hide
+     */
+    public static final String EXTRA_TRIGGER_TYPE = "trigger_type";
+
+
+    /**
+     * @hide
+     */
+    public static final String EXTRA_TRIGGER_STATE = "trigger_state";
+
     /**
      * Extra for {@link #INTENT_ACTION_PROFILE_SELECTED} and {@link #INTENT_ACTION_PROFILE_UPDATED}:
      * The name of the newly activated or updated profile


### PR DESCRIPTION
Notifies the ProfileTrustAgent when a WiFi/BT event was triggered even
if no new profile was selected so the trust agent can grant/revoke trust

Filters out the multiple network state change notifications to make sure
we notify the trust agent only when the event that the profile
is tracking actually happened

Change-Id: I047861a8b145762fff24568e341373a89ee01de9
TICKET: CYNGNOS-2719
