### PR TITLE
cmsdk: Fix non-triggered ON_DISCONNECT + cleanups

### DIFF
--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/ProfileTriggerHelper.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/ProfileTriggerHelper.java
@@ -107,26 +107,15 @@ public class ProfileTriggerHelper extends BroadcastReceiver {
         String action = intent.getAction();
 
         if (action.equals(WifiManager.NETWORK_STATE_CHANGED_ACTION)) {
-            Bundle extras = intent.getExtras();
-            WifiInfo wifiInfo = extras.getParcelable(WifiManager.EXTRA_WIFI_INFO);
-            if (wifiInfo != null) {
-                String ssid = wifiInfo.getSSID();
-                if (ssid != null) {
-                    // SSID will be surrounded by double quotation marks if it can be decoded
-                    // as UTF-8
-                    if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
-                        ssid = ssid.substring(1, ssid.length()-1);
-                    }
-                    if (TextUtils.equals(ssid, WifiSsid.NONE)) {
-                        checkTriggers(Profile.TriggerType.WIFI, mLastConnectedSSID,
-                                Profile.TriggerState.ON_DISCONNECT);
-                        mLastConnectedSSID = WifiSsid.NONE;
-                    } else if (!TextUtils.equals(mLastConnectedSSID, ssid)) {
-                        mLastConnectedSSID = ssid;
-                        checkTriggers(Profile.TriggerType.WIFI, mLastConnectedSSID,
-                                Profile.TriggerState.ON_CONNECT);
-                    }
-                }
+            String ssid = getActiveSSID();
+            if (ssid == null || TextUtils.equals(ssid, WifiSsid.NONE)) {
+                checkTriggers(Profile.TriggerType.WIFI, mLastConnectedSSID,
+                        Profile.TriggerState.ON_DISCONNECT);
+                mLastConnectedSSID = WifiSsid.NONE;
+            } else if (!TextUtils.equals(mLastConnectedSSID, ssid)) {
+                mLastConnectedSSID = ssid;
+                checkTriggers(Profile.TriggerType.WIFI, mLastConnectedSSID,
+                        Profile.TriggerState.ON_CONNECT);
             }
         } else if (action.equals(BluetoothDevice.ACTION_ACL_CONNECTED)
                 || action.equals(BluetoothDevice.ACTION_ACL_DISCONNECTED)) {


### PR DESCRIPTION
* the WifiInfo object may be null if there is no active connection
which should trigger an ON_DISCONNECT
* by using the already existing "getActiveSSID"-method there is no
need to cleanup UTF-8 encoded SSIDs

Change-Id: I69e4db55753ca1e02afde59b186dae822adf7b63